### PR TITLE
Add a .github/CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
+
+* @jobandtalent/platform


### PR DESCRIPTION
This way we can assign automatically the PRs to the
@jobandtalent/platform team. I left the documentation in a comment, as
we can do more fancy stuff in that file, eg files with specific
extension or directories get assigned to specific people/teams.